### PR TITLE
Add support for multiple variations of the same word

### DIFF
--- a/example.dslf
+++ b/example.dslf
@@ -1,7 +1,8 @@
 mood: high       # comments are supported :-D
-how (are you doing?)|(is it going);
-[has_place] how is it going over there;
-[french] comment "êtes" voùs;  # quotes make sure êtes is matched diacritics-sensitively
+how (are you doing?)|(is it go<ing|ne>);
+[has_place] how is it going over <t?>here;
+[french] comment "êtes" voùs;  # quotes make sure êtes is matched diacritics-sensitively,
+                               # while voùs will be matched the same way as vous
 
 GPS_navigation: medium
 [question]  take|bring me to .place. (by .vehicle.)? please?;

--- a/sentences_compiler/src/main/java/org/dicio/sentences_compiler/compiler/CompilerToJava.java
+++ b/sentences_compiler/src/main/java/org/dicio/sentences_compiler/compiler/CompilerToJava.java
@@ -84,6 +84,8 @@ public class CompilerToJava extends CompilerBase {
                 + "import org.dicio.skill.standard.StandardRecognizerData;\n"
                 + "import org.dicio.skill.standard.word.DiacriticsInsensitiveWord;\n"
                 + "import org.dicio.skill.standard.word.DiacriticsSensitiveWord;\n"
+                + "import org.dicio.skill.standard.word.DiacriticsInsensitiveRegexWord;\n"
+                + "import org.dicio.skill.standard.word.DiacriticsSensitiveRegexWord;\n"
                 + "import org.dicio.skill.standard.word.CapturingGroup;\n"
                 + "public class ");
         output.write(className);

--- a/sentences_compiler/src/main/java/org/dicio/sentences_compiler/construct/Word.java
+++ b/sentences_compiler/src/main/java/org/dicio/sentences_compiler/construct/Word.java
@@ -1,5 +1,7 @@
 package org.dicio.sentences_compiler.construct;
 
+import org.dicio.sentences_compiler.util.StringNormalizer;
+
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.text.Normalizer;
@@ -8,10 +10,6 @@ import java.util.Set;
 import java.util.regex.Pattern;
 
 public final class Word extends WordBase {
-
-    private static final Pattern diacriticalMarksRemover =
-            Pattern.compile("\\p{InCombiningDiacriticalMarks}+");
-
 
     private final String value;
     private final boolean diacriticsSensitive;
@@ -35,11 +33,6 @@ public final class Word extends WordBase {
         return diacriticsSensitive;
     }
 
-    public String nfkdNormalized() {
-        final String normalized = Normalizer.normalize(value, Normalizer.Form.NFKD);
-        return diacriticalMarksRemover.matcher(normalized).replaceAll("");
-    }
-
 
     @Override
     public void compileToJava(final OutputStreamWriter output,
@@ -49,7 +42,7 @@ public final class Word extends WordBase {
             output.write(value);
         } else {
             output.write("new DiacriticsInsensitiveWord(\"");
-            output.write(nfkdNormalized());
+            output.write(StringNormalizer.nfkdNormalize(value));
         }
 
         output.write("\",");

--- a/sentences_compiler/src/main/java/org/dicio/sentences_compiler/construct/WordWithVariations.java
+++ b/sentences_compiler/src/main/java/org/dicio/sentences_compiler/construct/WordWithVariations.java
@@ -1,0 +1,83 @@
+package org.dicio.sentences_compiler.construct;
+
+import org.dicio.sentences_compiler.util.StringNormalizer;
+
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+public class WordWithVariations extends WordBase {
+
+    private final List<List<String>> parts;
+    private final boolean diacriticsSensitive;
+
+    /**
+     * @param parts contains a list of sub-lists of strings that represent a word with possible
+     *              variations. E.g. if a word with variations has to match "doing", "done",
+     *              "undoing", "undone", this list should be
+     *              {@code [["", "un"], ["do"], ["ing", "ne"]]}
+     * @param diacriticsSensitive if true match the word exactly, otherwise ignore differences in
+     *                            diacritics/accents (see e.g. CTRL+F -> Match Diacritics in
+     *                            Firefox)
+     */
+    public WordWithVariations(final List<List<String>> parts, final boolean diacriticsSensitive) {
+        this.parts = parts;
+        this.diacriticsSensitive = diacriticsSensitive;
+    }
+
+    public List<List<String>> getParts() {
+        return parts;
+    }
+
+    public boolean isDiacriticsSensitive() {
+        return diacriticsSensitive;
+    }
+
+
+    public String toJavaRegex() {
+        final StringBuilder result = new StringBuilder();
+        for (final List<String> part : parts) {
+            if (part.size() == 1) {
+                result.append(part.get(0));
+
+            } else {
+                result.append("(?:");
+                for (int i = 0; i < part.size(); ++i) {
+                    if (i != 0) {
+                        result.append("|");
+                    }
+
+                    if (diacriticsSensitive) {
+                        result.append(part.get(i));
+                    } else {
+                        result.append(StringNormalizer.nfkdNormalize(part.get(i)));
+                    }
+                }
+                result.append(")");
+            }
+        }
+        return result.toString();
+    }
+
+    @Override
+    public void compileToJava(final OutputStreamWriter output,
+                              final String variableName) throws IOException {
+        if (diacriticsSensitive) {
+            output.write("new DiacriticsSensitiveRegexWord(\"");
+        } else {
+            output.write("new DiacriticsInsensitiveRegexWord(\"");
+        }
+        output.write(toJavaRegex());
+
+        output.write("\",");
+        super.compileToJava(output, variableName);
+        output.write(")");
+    }
+
+    @Override
+    public Set<String> getCapturingGroupNames() {
+        return Collections.emptySet();
+    }
+}

--- a/sentences_compiler/src/main/java/org/dicio/sentences_compiler/lexer/Tokenizer.java
+++ b/sentences_compiler/src/main/java/org/dicio/sentences_compiler/lexer/Tokenizer.java
@@ -9,26 +9,33 @@ public class Tokenizer {
     private final TokenStream ts;
     private InputStreamReader input;
     private int line, column;
+    private String ch, prevCh;
 
     public Tokenizer() {
         ts = new TokenStream();
     }
 
-    private void setInputStream(InputStreamReader input) {
+    private void setInputStream(final InputStreamReader input) {
         this.input = input;
         line = 1;
         column = 0;
+        ch = "";
+        prevCh = "";
     }
-    private String getCh() throws IOException {
+
+    private void getCh() throws IOException {
+        prevCh = ch;
+
         int intCh = input.read();
         if (intCh == -1) {
-            return "";
+            ch = "";
+        } else {
+            ++column;
+            ch = new String(Character.toChars(intCh));
         }
-
-        ++column;
-        return new String(Character.toChars(intCh));
     }
-    private Token.Type updateWordType(Token.Type currentWordType, String ch) {
+
+    private Token.Type updateWordType(final Token.Type currentWordType, final String ch) {
         if (currentWordType == Token.Type.lettersPlusOther || isOtherValid(ch)) {
             return Token.Type.lettersPlusOther;
         } else {
@@ -36,15 +43,19 @@ public class Tokenizer {
         }
     }
 
+
     private boolean isSpace(String ch) {
-        return Character.isWhitespace(ch.codePointAt(0)) && !ch.equals("\n");
+        return !ch.isEmpty() && !ch.equals("\n") && Character.isWhitespace(ch.codePointAt(0));
     }
+
     private boolean isLetter(String ch) {
-        return Character.isLetter(ch.codePointAt(0));
+        return !ch.isEmpty() && Character.isLetter(ch.codePointAt(0));
     }
+
     private boolean isOtherValid(String ch) {
-        return Character.isDigit(ch.codePointAt(0)) || ch.equals("_");
+        return !ch.isEmpty() && (Character.isDigit(ch.codePointAt(0)) || ch.equals("_"));
     }
+
     private boolean isGrammar(String ch) {
         switch (ch) {
             case ":": case ";": case "|": case "?": case ".":
@@ -55,46 +66,86 @@ public class Tokenizer {
         }
     }
 
-    public void tokenize(InputStreamReader inputStreamReader, String inputStreamName) throws IOException, CompilerError {
-        setInputStream(inputStreamReader);
-        String ch = getCh();
 
-        while (!ch.isEmpty()) {
-            if (isLetter(ch) || isOtherValid(ch)) {
-                StringBuilder word = new StringBuilder(ch);
-                Token.Type wordType = Token.Type.letters;
-                int firstCharCol = column;
+    public void tokenize(final InputStreamReader inputStreamReader,
+                         final String inputStreamName) throws IOException, CompilerError {
+        try {
+            setInputStream(inputStreamReader);
+            getCh();
 
-                while (true) {
-                    wordType = updateWordType(wordType, ch);
-                    ch = getCh();
-                    if (!ch.isEmpty() && (isLetter(ch) || isOtherValid(ch))) {
-                        word.append(ch);
-                    } else {
-                        break;
+            while (!ch.isEmpty()) {
+                if (isLetter(ch) || isOtherValid(ch)) {
+                    StringBuilder word = new StringBuilder(ch);
+                    Token.Type wordType = Token.Type.letters;
+                    int firstCharCol = column;
+
+                    while (true) {
+                        wordType = updateWordType(wordType, ch);
+                        getCh();
+                        if (!ch.isEmpty() && (isLetter(ch) || isOtherValid(ch))) {
+                            word.append(ch);
+                        } else {
+                            break;
+                        }
                     }
-                }
 
-                ts.push(new Token(wordType, word.toString(), inputStreamName, line, firstCharCol));
-            } else if (isGrammar(ch)) {
-                ts.push(new Token(Token.Type.grammar, ch, inputStreamName, line, column));
-                ch = getCh();
-            } else if (ch.equals("\n")) {
-                ++line;
-                column = 0;
-                ch = getCh();
-            } else if (ch.equals("#")) {
-                while (!ch.equals("\n") && !ch.isEmpty()) {
-                    ch = getCh();
+                    ts.push(new Token(
+                            wordType, word.toString(), inputStreamName, line, firstCharCol));
+
+                } else if (isGrammar(ch)) {
+                    ts.push(new Token(Token.Type.grammar, ch, inputStreamName, line, column));
+                    getCh();
+
+                } else if (ch.equals("<")) {
+                    final String tokenValue;
+                    if (isLetter(prevCh) || prevCh.equals(">")) {
+                        tokenValue = "<"; // connected to the word before it
+                    } else {
+                        tokenValue = " <"; // not connected to a previous word
+                    }
+                    ts.push(new Token(
+                            Token.Type.grammar, tokenValue, inputStreamName, line, column));
+                    getCh();
+
+                } else if (ch.equals(">")) {
+                    final int originalColumn = column;
+                    getCh();
+                    final String tokenValue;
+                    if (isLetter(ch) || ch.equals("<")) {
+                        tokenValue = ">"; // connected to the word after it
+                    } else {
+                        tokenValue = "> "; // not connected to a next word
+                    }
+                    ts.push(new Token(
+                            Token.Type.grammar, tokenValue, inputStreamName, line, originalColumn));
+
+                } else if (ch.equals("\n")) {
+                    ++line;
+                    column = 0;
+                    getCh();
+
+                } else if (ch.equals("#")) {
+                    while (!ch.equals("\n") && !ch.isEmpty()) {
+                        getCh();
+                    }
+
+                } else if (isSpace(ch)) {
+                    getCh();
+
+                } else {
+                    throw new CompilerError(CompilerError.Type.invalidCharacter, ch,
+                            inputStreamName, line, column, "");
                 }
-            } else if (isSpace(ch)) {
-                ch = getCh();
-            } else {
-                throw new CompilerError(CompilerError.Type.invalidCharacter, ch, inputStreamName, line, column, "");
             }
-        }
 
-        ts.push(new Token(Token.Type.endOfFile, "", inputStreamName, line, column+1));
+            ts.push(new Token(Token.Type.endOfFile, "", inputStreamName, line, column+1));
+
+        } finally {
+            // allow garbage collector to kick in
+            this.input = null;
+            ch = null;
+            prevCh = null;
+        }
     }
 
     public TokenStream getTokenStream() {

--- a/sentences_compiler/src/main/java/org/dicio/sentences_compiler/util/CompilerError.java
+++ b/sentences_compiler/src/main/java/org/dicio/sentences_compiler/util/CompilerError.java
@@ -13,6 +13,7 @@ public class CompilerError extends Exception {
         expectedSentenceContent("Expected sentence content after sentence id"),
         expectedSentenceConstructList("Expected list of sentence constructs"),
         expectedWordValue("Expected diacritics-sensitive word value after opening quotation marks '\"'"),
+        invalidVariationsGroup("Invalid variations group"),
         expectedCapturingGroupName("Expected capturing group name after point \".\""),
         invalidCapturingGroupName("The capturing group name has to be a valid java variable name"),
         sentenceCanBeEmpty("Sentence can be unfolded to an empty sentence (possibly with capturing groups)"),

--- a/sentences_compiler/src/main/java/org/dicio/sentences_compiler/util/JavaSyntaxCheck.java
+++ b/sentences_compiler/src/main/java/org/dicio/sentences_compiler/util/JavaSyntaxCheck.java
@@ -26,7 +26,8 @@ public class JavaSyntaxCheck {
      */
     private static final String[] importedClasses = {
             "Map", "HashMap", "Specificity", "Sentence", "StandardRecognizerData",
-            "DiacriticsInsensitiveWord", "DiacriticsSensitiveWord", "CapturingGroup"
+            "DiacriticsInsensitiveWord", "DiacriticsSensitiveWord",
+            "DiacriticsInsensitiveRegexWord", "DiacriticsSensitiveRegexWord", "CapturingGroup"
     };
 
 

--- a/sentences_compiler/src/main/java/org/dicio/sentences_compiler/util/StringNormalizer.java
+++ b/sentences_compiler/src/main/java/org/dicio/sentences_compiler/util/StringNormalizer.java
@@ -1,0 +1,15 @@
+package org.dicio.sentences_compiler.util;
+
+import java.text.Normalizer;
+import java.util.regex.Pattern;
+
+public class StringNormalizer {
+
+    private static final Pattern diacriticalMarksRemover =
+            Pattern.compile("\\p{InCombiningDiacriticalMarks}+");
+
+    public static String nfkdNormalize(final String string) {
+        final String normalized = Normalizer.normalize(string, Normalizer.Form.NFKD);
+        return diacriticalMarksRemover.matcher(normalized).replaceAll("");
+    }
+}

--- a/sentences_compiler/src/test/java/org/dicio/sentences_compiler/construct/WordWithVariationsTest.java
+++ b/sentences_compiler/src/test/java/org/dicio/sentences_compiler/construct/WordWithVariationsTest.java
@@ -1,0 +1,33 @@
+package org.dicio.sentences_compiler.construct;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.regex.Pattern;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class WordWithVariationsTest {
+
+    @SuppressWarnings("ArraysAsListWithZeroOrOneArgument")
+    @Test
+    public void testToJavaRegex() {
+        final WordWithVariations word = new WordWithVariations(
+                Arrays.asList(
+                        Arrays.asList("à", "bcd", ""),
+                        Arrays.asList("èf", "ghì"),
+                        Arrays.asList("jk"),
+                        Arrays.asList("l", "mno", "p", ""),
+                        Arrays.asList("qr", "")),
+                false);
+        final String actualRegex = word.toJavaRegex();
+        assertEquals("(?:a|bcd|)(?:ef|ghi)jk(?:l|mno|p|)(?:qr|)", word.toJavaRegex());
+        final Pattern pattern = Pattern.compile(actualRegex);
+        assertTrue(pattern.matcher("efjkmnoqr").matches());
+        assertFalse(pattern.matcher("ajk").matches());
+        assertTrue(pattern.matcher("aefjk").matches());
+        assertFalse(pattern.matcher("àefjk").matches());
+    }
+}

--- a/sentences_compiler/src/test/java/org/dicio/sentences_compiler/lexer/TokenizerTest.java
+++ b/sentences_compiler/src/test/java/org/dicio/sentences_compiler/lexer/TokenizerTest.java
@@ -27,19 +27,19 @@ public class TokenizerTest {
     }
 
     private static void assertTokenEqualTo(Token token, Token.Type type, String value, int line, int column) {
-        assertTrue(token.isType(type));
-        assertTrue(token.isValue(value));
-        assertEquals(token.getLine(), line);
-        assertEquals(token.getColumn(), column);
+        assertTrue("Token type is not of type "+type, token.isType(type));
+        assertTrue("Token's value \""+token.getValue()+"\" is not \""+value+"\"", token.isValue(value));
+        assertEquals(line, token.getLine());
+        assertEquals(column, token.getColumn());
     }
-    private static void assertInvalid(String input, CompilerError.Type errorType, int errorLine, int errorColumn, String errorMustContain) throws IOException {
+    private static void assertInvalidCharacter(String input, int errorLine, int errorColumn, String errorMustContain) throws IOException {
         final String inputStreamName = "MyGoodFILE!";
         try {
             getTokens(input, inputStreamName);
             fail("No error thrown with invalid input");
         } catch (CompilerError compilerError) {
             String message = compilerError.getMessage();
-            assertTrue("\""+message+"\" is not of type \""+errorType.toString()+"\"", message.contains(errorType.toString()));
+            assertTrue("\""+message+"\" is not of type \""+ CompilerError.Type.invalidCharacter.toString()+"\"", message.contains(CompilerError.Type.invalidCharacter.toString()));
             assertTrue("\""+message+"\" does not contain input stream name \""+inputStreamName+"\"", message.contains(inputStreamName));
             assertTrue("\""+message+"\" does not contain line number "+errorLine, message.contains(String.valueOf(errorLine)));
             assertTrue("\""+message+"\" does not contain column number "+errorColumn, message.contains(String.valueOf(errorColumn)));
@@ -58,7 +58,7 @@ public class TokenizerTest {
     @Test
     public void testValidInput() throws IOException, CompilerError {
         TokenStream tokens = getTokens("cat_name1:     # hello world  \n" +
-                "  [sent_name1] hello?      hi|(bye bye);       \n" +
+                "  [sent_name1] hel<l|lo>?      hi|(bye bye);       \n" +
                 "..;");
         assertTrue(tokens.get(-1).isEmpty());
         assertTokenEqualTo(tokens.get(0),  Token.Type.lettersPlusOther, "cat_name1",  1,  1);
@@ -66,27 +66,77 @@ public class TokenizerTest {
         assertTokenEqualTo(tokens.get(2),  Token.Type.grammar,          "[",          2,  3);
         assertTokenEqualTo(tokens.get(3),  Token.Type.lettersPlusOther, "sent_name1", 2,  4);
         assertTokenEqualTo(tokens.get(4),  Token.Type.grammar,          "]",          2, 14);
-        assertTokenEqualTo(tokens.get(5),  Token.Type.letters,          "hello",      2, 16);
-        assertTokenEqualTo(tokens.get(6),  Token.Type.grammar,          "?",          2, 21);
-        assertTokenEqualTo(tokens.get(7),  Token.Type.letters,          "hi",         2, 28);
-        assertTokenEqualTo(tokens.get(8),  Token.Type.grammar,          "|",          2, 30);
-        assertTokenEqualTo(tokens.get(9),  Token.Type.grammar,          "(",          2, 31);
-        assertTokenEqualTo(tokens.get(10), Token.Type.letters,          "bye",        2, 32);
-        assertTokenEqualTo(tokens.get(11), Token.Type.letters,          "bye",        2, 36);
-        assertTokenEqualTo(tokens.get(12), Token.Type.grammar,          ")",          2, 39);
-        assertTokenEqualTo(tokens.get(13), Token.Type.grammar,          ";",          2, 40);
-        assertTokenEqualTo(tokens.get(14), Token.Type.grammar,          ".",          3,  1);
-        assertTokenEqualTo(tokens.get(15), Token.Type.grammar,          ".",          3,  2);
-        assertTokenEqualTo(tokens.get(16), Token.Type.grammar,          ";",          3,  3);
-        assertTrue(tokens.get(17).isType(Token.Type.endOfFile));
-        assertTrue(tokens.get(18).isEmpty());
+        assertTokenEqualTo(tokens.get(5),  Token.Type.letters,          "hel",        2, 16);
+        assertTokenEqualTo(tokens.get(6),  Token.Type.grammar,          "<",          2, 19);
+        assertTokenEqualTo(tokens.get(7),  Token.Type.letters,          "l",          2, 20);
+        assertTokenEqualTo(tokens.get(8),  Token.Type.grammar,          "|",          2, 21);
+        assertTokenEqualTo(tokens.get(9),  Token.Type.letters,          "lo",         2, 22);
+        assertTokenEqualTo(tokens.get(10), Token.Type.grammar,          "> ",         2, 24);
+        assertTokenEqualTo(tokens.get(11), Token.Type.grammar,          "?",          2, 25);
+        assertTokenEqualTo(tokens.get(12), Token.Type.letters,          "hi",         2, 32);
+        assertTokenEqualTo(tokens.get(13), Token.Type.grammar,          "|",          2, 34);
+        assertTokenEqualTo(tokens.get(14), Token.Type.grammar,          "(",          2, 35);
+        assertTokenEqualTo(tokens.get(15), Token.Type.letters,          "bye",        2, 36);
+        assertTokenEqualTo(tokens.get(16), Token.Type.letters,          "bye",        2, 40);
+        assertTokenEqualTo(tokens.get(17), Token.Type.grammar,          ")",          2, 43);
+        assertTokenEqualTo(tokens.get(18), Token.Type.grammar,          ";",          2, 44);
+        assertTokenEqualTo(tokens.get(19), Token.Type.grammar,          ".",          3,  1);
+        assertTokenEqualTo(tokens.get(20), Token.Type.grammar,          ".",          3,  2);
+        assertTokenEqualTo(tokens.get(21), Token.Type.grammar,          ";",          3,  3);
+        assertTrue(tokens.get(22).isType(Token.Type.endOfFile));
+        assertTrue(tokens.get(23).isEmpty());
     }
 
     @Test
     public void testInvalidInput() throws IOException {
-        assertInvalid("\n\n\n+\n+",              CompilerError.Type.invalidCharacter, 4, 1, "+");
-        assertInvalid("\n[[[]<",                 CompilerError.Type.invalidCharacter, 2, 5, "<");
-        assertInvalid("   \n  *\n\n+",           CompilerError.Type.invalidCharacter, 2, 3, "*");
-        assertInvalid("[[][\n\t]](\n(%)):;)):(", CompilerError.Type.invalidCharacter, 3, 2, "%");
+        assertInvalidCharacter("\n\n\n+\n+",              4, 1, "+");
+        assertInvalidCharacter("\n[[[]{",                 2, 5, "{");
+        assertInvalidCharacter("   \n  *\n\n+",           2, 3, "*");
+        assertInvalidCharacter("[[][\n\t]](\n(%)):;)):(", 3, 2, "%");
+    }
+
+    @Test
+    public void testAngleBracketsInInput() throws IOException, CompilerError {
+        TokenStream tokens = getTokens(">a\n< > <<<>>><<< <bcd>\n>efg<\th<i>j<?<k>?>l m<");
+        assertTokenEqualTo(tokens.get(0),  Token.Type.grammar, ">",   1,  1);
+        assertTokenEqualTo(tokens.get(1),  Token.Type.letters, "a",   1,  2);
+        assertTokenEqualTo(tokens.get(2),  Token.Type.grammar, " <",  2,  1);
+        assertTokenEqualTo(tokens.get(3),  Token.Type.grammar, "> ",  2,  3);
+        assertTokenEqualTo(tokens.get(4),  Token.Type.grammar, " <",  2,  5);
+        assertTokenEqualTo(tokens.get(5),  Token.Type.grammar, " <",  2,  6);
+        assertTokenEqualTo(tokens.get(6),  Token.Type.grammar, " <",  2,  7);
+        assertTokenEqualTo(tokens.get(7),  Token.Type.grammar, "> ",  2,  8);
+        assertTokenEqualTo(tokens.get(8),  Token.Type.grammar, "> ",  2,  9);
+        assertTokenEqualTo(tokens.get(9),  Token.Type.grammar, ">",   2, 10);
+        assertTokenEqualTo(tokens.get(10), Token.Type.grammar, "<",   2, 11);
+        assertTokenEqualTo(tokens.get(11), Token.Type.grammar, " <",  2, 12);
+        assertTokenEqualTo(tokens.get(12), Token.Type.grammar, " <",  2, 13);
+        assertTokenEqualTo(tokens.get(13), Token.Type.grammar, " <",  2, 15);
+        assertTokenEqualTo(tokens.get(14), Token.Type.letters, "bcd", 2, 16);
+        assertTokenEqualTo(tokens.get(15), Token.Type.grammar, "> ",  2, 19);
+        assertTokenEqualTo(tokens.get(16), Token.Type.grammar, ">",   3,  1);
+        assertTokenEqualTo(tokens.get(17), Token.Type.letters, "efg", 3,  2);
+        assertTokenEqualTo(tokens.get(18), Token.Type.grammar, "<",   3,  5);
+        assertTokenEqualTo(tokens.get(19), Token.Type.letters, "h",   3,  7);
+        assertTokenEqualTo(tokens.get(20), Token.Type.grammar, "<",   3,  8);
+        assertTokenEqualTo(tokens.get(21), Token.Type.letters, "i",   3,  9);
+        assertTokenEqualTo(tokens.get(22), Token.Type.grammar, ">",   3, 10);
+        assertTokenEqualTo(tokens.get(23), Token.Type.letters, "j",   3, 11);
+        assertTokenEqualTo(tokens.get(24), Token.Type.grammar, "<",   3, 12);
+        assertTokenEqualTo(tokens.get(25), Token.Type.grammar, "?",   3, 13);
+        assertTokenEqualTo(tokens.get(26), Token.Type.grammar, " <",  3, 14);
+        assertTokenEqualTo(tokens.get(27), Token.Type.letters, "k",   3, 15);
+        assertTokenEqualTo(tokens.get(28), Token.Type.grammar, "> ",  3, 16);
+        assertTokenEqualTo(tokens.get(29), Token.Type.grammar, "?",   3, 17);
+        assertTokenEqualTo(tokens.get(30), Token.Type.grammar, ">",   3, 18);
+        assertTokenEqualTo(tokens.get(31), Token.Type.letters, "l",   3, 19);
+        assertTokenEqualTo(tokens.get(32), Token.Type.letters, "m",   3, 21);
+        assertTokenEqualTo(tokens.get(33), Token.Type.grammar, "<",   3, 22);
+
+        tokens = getTokens("<");
+        assertTokenEqualTo(tokens.get(0), Token.Type.grammar, " <",  1, 1);
+
+        tokens = getTokens(">");
+        assertTokenEqualTo(tokens.get(0), Token.Type.grammar, "> ",  1, 1);
     }
 }


### PR DESCRIPTION
This PR implements support for word variations, using the syntax `<|?>`. For example, if one wanted a word that matches "mail", "email" and "gmail", they would write `<e|g?>mail`, which is far shorter than (but roughly equivalent to) the or-list `mail|email|gmail` (which is currently the only method supported). `<>` groups can appear anywhere in the word (at the beginning, at the end or in the middle), and there can even be multiple ones of them. The important thing to remember is not to insert spaces in between letters and `<` or `>`: for example `o <n|ff> line` would represent three words (equivalent to `o n|ff line`) instead of just one! The correct way to write it is without spaces, i.e. `o<n|ff>line`, which would be equivalent to `online|offline`.

Fixes #5
Fixes Stypox/dicio-android#27
Also see Stypox/dicio-android#26 and Stypox/dicio-android#36
This PR requires Stypox/dicio-skill#4

~~TODO: add an explanation to the README~~ done